### PR TITLE
[Merged by Bors] - chore: change strategy for bors commit message linting

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,9 +1,7 @@
 use_squash_merge = true
 cut_body_after = "_ _ _"
-pr_status = [
-  "Validate conventional PR title",
-]
 status = [
+  "Lint commit message",
   "Check Rust formatting",
   "Clippy correctness checks (%)",
   "Build Docs",

--- a/.github/workflows/bors-commit-lint.yml
+++ b/.github/workflows/bors-commit-lint.yml
@@ -1,0 +1,17 @@
+name: Lint commit message
+on:
+  push:
+    branches:
+      - main
+      - staging
+      - trying
+
+jobs:
+  commitlint:
+    name: Lint commit message
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wagoid/commitlint-github-action@v5
+        with:
+          commitDepth: 1


### PR DESCRIPTION
Bors seems to be having trouble checking the PR status
and making sure the PR title is a conventional commit message.

This changes it so that bors ignores the PR status,
but runs a check on the generated commit,
making sure that it matches the conventional commit specification.